### PR TITLE
Added support for isomorphic applications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-responsive",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Utilities for easily creating responsive designs in a redux architecture.",
   "main": "build/index.js",
   "repository": {

--- a/src/util/addEventHandlers.js
+++ b/src/util/addEventHandlers.js
@@ -15,17 +15,17 @@ import calculateResponsiveState from '../actions/creators/calculateResponsiveSta
  * @arg {boolean} options.calculateStateInitially - True if the responsive state
  * must be calculated initially, false otherwise.
  */
-export default (store, options) => {
+export default (store, {throttleTime, calculateStateInitially}) => {
     // if there is a `window`
     if (typeof window !== 'undefined') {
         // throttled event handler for window resize
         const throttledHandler = throttle(
             // just dispatch action to calculate responsive state
             () => store.dispatch(calculateResponsiveState(window)),
-            options.throttleTime
+            throttleTime
         )
         // initialize the responsive state
-        if (options.calculateStateInitially) {
+        if (calculateStateInitially) {
             throttledHandler()
         }
         // add the resize event listener

--- a/src/util/addEventHandlers.js
+++ b/src/util/addEventHandlers.js
@@ -9,20 +9,25 @@ import calculateResponsiveState from '../actions/creators/calculateResponsiveSta
  * (throttled) window resize event listener (which will dispatch further such
  * actions).
  * @arg {object} store - The redux store.  Really you only need to pass `{dispatch}`.
- * @arg {number} throttleTime - Throttle time (in miliseconds) for the
+ * @arg {object} options - Options.
+ * @arg {number} options.throttleTime - Throttle time (in miliseconds) for the
  * window resize event handler.
+ * @arg {boolean} options.calculateStateInitially - True if the responsive state
+ * must be calculated initially, false otherwise.
  */
-export default (store, throttleTime) => {
+export default (store, options) => {
     // if there is a `window`
     if (typeof window !== 'undefined') {
         // throttled event handler for window resize
         const throttledHandler = throttle(
             // just dispatch action to calculate responsive state
             () => store.dispatch(calculateResponsiveState(window)),
-            throttleTime
+            options.throttleTime
         )
         // initialize the responsive state
-        throttledHandler()
+        if (options.calculateStateInitially) {
+            throttledHandler()
+        }
         // add the resize event listener
         window.addEventListener('resize', throttledHandler)
     }

--- a/src/util/createResponsiveStoreEnhancer.js
+++ b/src/util/createResponsiveStoreEnhancer.js
@@ -1,5 +1,3 @@
-// third party imports
-import assign from 'lodash/assign'
 // local imports
 import addEventHandlers from './addEventHandlers'
 
@@ -13,18 +11,11 @@ import addEventHandlers from './addEventHandlers'
  * @returns {function} - The store enhancer (which adds event listeners to
  * dispatch actions on window resize).
  */
-export default (options) => {
-    const defaultOptions = {
-        throttleTime: 100,
-        calculateStateInitially: true,
-    }
-    // assign default values
-    assign(defaultOptions, options)
-
+export default ({throttleTime = 100, calculateStateInitially = true} = {}) => {
     // return store enhancer
     return (createStore) =>
         // return enhanced version of `createStore`
         (...args) =>
             // return store after adding event handlers
-            addEventHandlers(createStore(...args), defaultOptions)
+            addEventHandlers(createStore(...args), {throttleTime, calculateStateInitially})
 }

--- a/src/util/createResponsiveStoreEnhancer.js
+++ b/src/util/createResponsiveStoreEnhancer.js
@@ -3,15 +3,34 @@ import addEventHandlers from './addEventHandlers'
 
 /**
  * Creates a store enhancer based off an (optional) throttle time.
- * @arg {number} [throttleTime=100] - Throttle time (in miliseconds) for the
- * window resize event handler.
+ * @arg {(object|number)} [options={throttleTime,calculateStateInitially}]
+ * - Options object or the throttle time.
+ * @arg {number} [options.throttleTime=100] - Throttle time (in miliseconds) for
+ * the window resize event handler.
+ * @arg {boolean} [options.calculateStateInitially=true] - True if the responsive
+ * state must be calculated initially, false otherwise.
  * @returns {function} - The store enhancer (which adds event listeners to
  * dispatch actions on window resize).
  */
-export default (throttleTime = 100) =>
+export default (options = {throttleTime: 100, calculateStateInitially: true}) => {
+    // options object normalization
+    const normalizedOptions = {
+        throttleTime: 100,
+        calculateStateInitially: true,
+    }
+    if (typeof options === 'number') {
+        normalizedOptions.throttleTime = options
+    } else if (typeof options.throttleTime !== 'undefined') {
+        normalizedOptions.throttleTime = options.throttleTime
+    }
+    if (typeof options.calculateStateInitially !== 'undefined') {
+        normalizedOptions.calculateStateInitially = options.calculateStateInitially
+    }
+
     // return store enhancer
-    (createStore) =>
+    return (createStore) =>
         // return enhanced version of `createStore`
         (...args) =>
             // return store after adding event handlers
-            addEventHandlers(createStore(...args), throttleTime)
+            addEventHandlers(createStore(...args), normalizedOptions)
+}

--- a/src/util/createResponsiveStoreEnhancer.js
+++ b/src/util/createResponsiveStoreEnhancer.js
@@ -1,10 +1,11 @@
+// third party imports
+import assign from 'lodash/assign'
 // local imports
 import addEventHandlers from './addEventHandlers'
 
 /**
  * Creates a store enhancer based off an (optional) throttle time.
- * @arg {(object|number)} [options={throttleTime,calculateStateInitially}]
- * - Options object or the throttle time.
+ * @arg {object} [options={throttleTime,calculateStateInitially}] - Options object.
  * @arg {number} [options.throttleTime=100] - Throttle time (in miliseconds) for
  * the window resize event handler.
  * @arg {boolean} [options.calculateStateInitially=true] - True if the responsive
@@ -12,25 +13,18 @@ import addEventHandlers from './addEventHandlers'
  * @returns {function} - The store enhancer (which adds event listeners to
  * dispatch actions on window resize).
  */
-export default (options = {throttleTime: 100, calculateStateInitially: true}) => {
-    // options object normalization
-    const normalizedOptions = {
+export default (options) => {
+    const defaultOptions = {
         throttleTime: 100,
         calculateStateInitially: true,
     }
-    if (typeof options === 'number') {
-        normalizedOptions.throttleTime = options
-    } else if (typeof options.throttleTime !== 'undefined') {
-        normalizedOptions.throttleTime = options.throttleTime
-    }
-    if (typeof options.calculateStateInitially !== 'undefined') {
-        normalizedOptions.calculateStateInitially = options.calculateStateInitially
-    }
+    // assign default values
+    assign(defaultOptions, options)
 
     // return store enhancer
     return (createStore) =>
         // return enhanced version of `createStore`
         (...args) =>
             // return store after adding event handlers
-            addEventHandlers(createStore(...args), normalizedOptions)
+            addEventHandlers(createStore(...args), defaultOptions)
 }

--- a/tests/test_addEventHandlers.js
+++ b/tests/test_addEventHandlers.js
@@ -8,17 +8,29 @@ describe('addEventHandlers', function () {
         const store = {dispatch: () => ({})}
 
         // should return same value it is given
-        expect(addEventHandlers(store)).to.equal(store)
+        expect(addEventHandlers(store, {throttleTime: 100, calculateStateInitially: true})).to.equal(store)
     })
 
 
-    it('calls the dispatch property of the store arg', function () {
-        const dispatchSpy = sinon.spy()
+    it('respects the calculateStateInitially option', function () {
+        const dispatchSpy1 = sinon.spy()
+        const dispatchSpy2 = sinon.spy()
 
-        addEventHandlers({dispatch: dispatchSpy})
+        addEventHandlers(
+            {dispatch: dispatchSpy1},
+            {throttleTime: 100, calculateStateInitially: true}
+        )
 
         // should have triggered our dispatch spy exactly once
-        expect(dispatchSpy).to.have.been.calledOnce
+        expect(dispatchSpy1).to.have.been.calledOnce
+        
+        addEventHandlers(
+            {dispatch: dispatchSpy2},
+            {calculateStateInitially: false}
+        )
+
+        // should not dispatch recalculation
+        expect(!dispatchSpy2.called)
     })
 
 

--- a/tests/test_createResponsiveStoreEnhancer.js
+++ b/tests/test_createResponsiveStoreEnhancer.js
@@ -5,10 +5,6 @@ import createResponsiveStoreEnhancer from 'util/createResponsiveStoreEnhancer'
 
 
 describe('createResponsiveStoreEnhancer', function () {
-    it('returns a function when given a throttle time', function () {
-        expect(isFunction(createResponsiveStoreEnhancer(500))).to.be.true
-    })
-
     it('returns a function when given an options object', function () {
         expect(isFunction(createResponsiveStoreEnhancer({}))).to.be.true
     })

--- a/tests/test_createResponsiveStoreEnhancer.js
+++ b/tests/test_createResponsiveStoreEnhancer.js
@@ -9,7 +9,11 @@ describe('createResponsiveStoreEnhancer', function () {
         expect(isFunction(createResponsiveStoreEnhancer(500))).to.be.true
     })
 
-    it('returns a function when not given a throttle time', function () {
+    it('returns a function when given an options object', function () {
+        expect(isFunction(createResponsiveStoreEnhancer({}))).to.be.true
+    })
+
+    it('returns a function when not given any options', function () {
         expect(isFunction(createResponsiveStoreEnhancer())).to.be.true
     })
 


### PR DESCRIPTION
See issue #17 
Adds the `calculateStateInitially` option to the `createResponsiveStoreEnhancer` factory method. When set to `false` it skips the initial responsive state calculation.