### PR TITLE
Add window to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ ReactDOM.render(
 )
 
 // calculate the initial state
-store.dispatch(calculateResponsiveState())
+store.dispatch(calculateResponsiveState(window))
 
 ```
 

--- a/src/actions/creators/calculateResponsiveState.js
+++ b/src/actions/creators/calculateResponsiveState.js
@@ -21,4 +21,4 @@ export default ({innerWidth, innerHeight, matchMedia} = {}) => ({
     innerWidth,
     innerHeight,
     matchMedia,
-});
+})

--- a/src/actions/creators/calculateResponsiveState.js
+++ b/src/actions/creators/calculateResponsiveState.js
@@ -16,11 +16,9 @@ import {CALCULATE_RESPONSIVE_STATE} from '../types'
  * `CALCULATE_RESPONSIVE_STATE`, and will be directly given the two keys taken
  * from the `window` argument.
  */
-export default ({innerWidth, innerHeight, matchMedia} = {}) => {
-    return {
-        type: CALCULATE_RESPONSIVE_STATE,
-        innerWidth,
-        innerHeight,
-        matchMedia,
-    }
-}
+export default ({innerWidth, innerHeight, matchMedia} = {}) => ({
+    type: CALCULATE_RESPONSIVE_STATE,
+    innerWidth,
+    innerHeight,
+    matchMedia,
+});


### PR DESCRIPTION
In order to properly calculate the responsive state after react is done with processing the server-side state, `window` has to be passed to the action creator.

This PR just adds that piece of information to the README (and shortens the actionCreator itself a little bit).

Might I also suggest to tag the commit you used for a npm release in the future? This makes it easier to see if an issue got fixed after a specific version.

Thanks for your work, much appreciated! :)