### PR TITLE
Dep cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js:
   - "5"
 # command to install dependencies
 install:
-  - npm install 
+  - npm install react react-redux
+  - npm install
 # command to run tests
 script:
   - npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-responsive",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Utilities for easily creating responsive designs in a redux architecture.",
   "main": "build/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,6 @@
   "dependencies": {
     "lodash": "^4.2.1",
     "mediaquery": "0.0.3",
-    "react": "^15.0.0",
-    "react-redux": "^4.4.5",
     "redux": "^3.5.2"
   }
 }


### PR DESCRIPTION
This PR removes react/react-redux as an explicit dependency in order to provided better support for non-react applications.

Resolves #27 