### PR TITLE
removed orEqual state attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ The `responsiveStateReducer` (and the reducer returned by `createResponsiveState
 - `orientation`: (*string*) The browser orientation. Has three possible values: "portrait", "landscape", or `null`.
 - `lessThan`: (*object*) An object of booleans that indicate whether the browser is currently less than a particular breakpoint.
 - `greaterThan`: (*object*) An object of booleans that indicate whether the browser is currently greater than a particular breakpoint.
-- `lessThanOrEqual`: (*object*) An object of booleans that indicate whether the browser is currently less than or equal to a particular breakpoint.
-- `greaterThanOrEqual`: (*object*) An object of booleans that indicate whether the browser is currently greater than or equal to a particular breakpoint.
 
 For example, if you put the responsive state under the key `browser` (as is done in the examples above) then you can access the browser's width and current media type, and determine if the browser is wider than the medium breakpoint like so
 
@@ -134,8 +132,6 @@ state.browser.mediaType
 state.browser.orientation
 // true if browser width is greater than the "medium" breakpoint
 state.browser.greaterThan.medium
-// true if the browser is less than or equal to the "medium" breakpoint
-state.browser.lessThanOrEqual.medium
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-responsive",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Utilities for easily creating responsive designs in a redux architecture.",
   "main": "index.js",
   "repository": {

--- a/src/util/createResponsiveStateReducer.js
+++ b/src/util/createResponsiveStateReducer.js
@@ -39,26 +39,6 @@ function getLessThan(browserWidth, breakpoints, currentMediaType) {
     })
 }
 
-/**
- * Compute the `lessThanOrEqual` object based on the browser width.
- * @arg {number} browserWidth - Width of the browser.
- * @arg {object} breakpoints - The breakpoints object.
- * @returns {object} The `lessThanOrEqual` object.  Its keys are the same as the
- * keys of the breakpoints object.  The value for each key indicates whether
- * or not the browser width is less than or equal to the breakpoint.
- */
-function getLessThanOrEqual(browserWidth, breakpoints, currentMediaType) {
-    return transform(breakpoints, (result, breakpoint, mediaType) => {
-        // if the breakpoint is a number
-        if (typeof breakpoint === 'number') {
-            // store wether or not it is less than the breakpoint
-            result[mediaType] = browserWidth < breakpoint || mediaType === currentMediaType
-        // handle non numerical breakpoints specially
-        } else {
-            result[mediaType] = false
-        }
-    })
-}
 
 /**
  * Compute the `greaterThan` object based on the browser width.
@@ -79,27 +59,6 @@ function getGreaterThan(browserWidth, breakpoints) {
         }
     })
 }
-
-/**
- * Compute the `greaterThanOrEqual` object based on the browser width.
- * @arg {number} browserWidth - Width of the browser.
- * @arg {object} breakpoints - The breakpoints object.
- * @returns {object} The `greaterThanOrEqual` object.  Its keys are the same as the
- * keys of the breakpoints object.  The value for each key indicates whether
- * or not the browser width is greater or equal to the breakpoint.
- */
-function getGreaterThanOrEqual(browserWidth, breakpoints, currentMediaType) {
-    return transform(breakpoints, (result, breakpoint, mediaType) => {
-        // if the breakpoint is a number
-        if (typeof breakpoint === 'number') {
-            // store wether or not it is greater than the breakpoint
-            result[mediaType] = browserWidth > breakpoint || mediaType === currentMediaType
-        } else {
-            result[mediaType] = false
-        }
-    })
-}
-
 
 
 /**
@@ -171,9 +130,7 @@ export default (breakpoints = defaultBreakpoints) => {
                 width: innerWidth,
                 height: innerHeight,
                 lessThan: getLessThan(innerWidth, breakpoints, mediaType),
-                lessThanOrEqual: getLessThanOrEqual(innerWidth, breakpoints, mediaType),
                 greaterThan: getGreaterThan(innerWidth, breakpoints),
-                greaterThanOrEqual: getGreaterThanOrEqual(innerWidth, breakpoints, mediaType),
                 mediaType,
                 orientation,
                 breakpoints,


### PR DESCRIPTION
Removed the "orEqual" responsive state attributes to keep the number of computations to a minimum when the browser resizes