### PR TITLE
Added performance mode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ export default combineReducers({
 
 The `responsiveStateReducer` (and the reducer returned by `createResponsiveStateReducer`) adds an object with the following keys to the store:
 
-- `width`: (*number*) The browser width.
-- `height`: (*number*) The browser height.
+- `width`: (*number*) The browser width. Note: With PerformanceMode enabled, this will take the value of the most recently matched breakpoint.
+- `height`: (*number*) The browser height. Note: With PerformanceMode enabled, this will take the value of the browser when the most recently matched breakpoint was satisfied.
 - `mediaType`: (*string*) The largest breakpoint category that the browser satisfies.
 - `orientation`: (*string*) The browser orientation. Has three possible values: "portrait", "landscape", or `null`.
 - `lessThan`: (*object*) An object of booleans that indicate whether the browser is currently less than a particular breakpoint.
@@ -222,6 +222,32 @@ ReactDOM.render(
 // calculate the initial state
 store.dispatch(calculateResponsiveState(window))
 ```
+
+# Performance Mode
+
+By default, the responsive state of your application is calculated every time
+the browser resizes. This incurs a very high overhead in large or very
+specialized apps. For those situations, redux-responsive provides a flag which
+limits the re-calculation of the responsive state to just when the state
+actually changes. Unfortunately, it relies on ["experimental" technology](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries#Browser_compatibility) that
+is only supported in modern browsers - hence the default is "off":
+
+
+```js
+// store/configureStore.js
+
+import {createStore} from 'redux'
+import {createResponsiveStoreEnhancer} from 'redux-responsive'
+import reducer from './reducer'
+
+const store = createStore(
+                    reducer,
+                    createResponsiveStoreEnhancer({performanceMode: true}))
+
+export default store
+```
+
+
 
 # Higher-Order Components
 

--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ By default, the responsive state of your application is calculated every time
 the browser resizes. This incurs a very high overhead in large or very
 specialized apps. For those situations, redux-responsive provides a flag which
 limits the re-calculation of the responsive state to just when the state
-actually changes. Unfortunately, it relies on ["experimental" technology](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries#Browser_compatibility) that
-is only supported in modern browsers - hence the default is "off":
+actually changes. When in performance mode, keep in mind that the browswer
+height and width are not continuously updating - they will only reflect the 
+state of the browser when the media query actually changed.
 
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-responsive",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Utilities for easily creating responsive designs in a redux architecture.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-responsive",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "Utilities for easily creating responsive designs in a redux architecture.",
   "main": "index.js",
   "repository": {

--- a/src/util/addEventHandlers.js
+++ b/src/util/addEventHandlers.js
@@ -1,8 +1,6 @@
-// third party imports
-import throttle from 'lodash/throttle'
 // local imports
-import calculateResponsiveState from '../actions/creators/calculateResponsiveState'
-
+import addThrottledHandlers from './addThrottledHandlers'
+import addPerformanceModeHandlers from './addPerformanceModeHandlers'
 
 /**
  * Dispatches an action to calculate the responsive state, then kicks of the
@@ -15,21 +13,18 @@ import calculateResponsiveState from '../actions/creators/calculateResponsiveSta
  * @arg {boolean} options.calculateStateInitially - True if the responsive state
  * must be calculated initially, false otherwise.
  */
-export default (store, {throttleTime, calculateStateInitially}) => {
+export default (store, {throttleTime, calculateStateInitially, performanceMode}) => {
     // if there is a `window`
     if (typeof window !== 'undefined') {
-        // throttled event handler for window resize
-        const throttledHandler = throttle(
-            // just dispatch action to calculate responsive state
-            () => store.dispatch(calculateResponsiveState(window)),
-            throttleTime
-        )
-        // initialize the responsive state
-        if (calculateStateInitially) {
-            throttledHandler()
+        // if we need to enable performance mode
+        if (performanceMode) {
+            // add the handlers that only fire when the responsive state changes
+            addPerformanceModeHandlers({store, window, calculateStateInitially})
+        // otherwise we should just add the throttled handlers
+        } else {
+            // add the throttled (continuously evaluated) handlers
+            addThrottledHandlers({store, window, throttleTime, calculateStateInitially})
         }
-        // add the resize event listener
-        window.addEventListener('resize', throttledHandler)
     }
 
     // return the store so that the call is transparent

--- a/src/util/addPerformanceModeHandlers.js
+++ b/src/util/addPerformanceModeHandlers.js
@@ -1,0 +1,72 @@
+// see: https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries
+
+// external imports
+import MediaQuery from 'mediaquery'
+// local imports
+import calculateResponsiveState from '../actions/creators/calculateResponsiveState'
+
+// this function adds event handlers to the window that only tirgger
+// when the responsive state changes
+export default ({store, window, calculateStateInitially}) => {
+    // the function to call when calculating the new responsive state
+    function refreshResponsiveState() {
+        store.dispatch(calculateResponsiveState(window))
+    }
+
+    // grab the current state of the store
+    const storeState = store.getState()
+
+    // go through every reducer at the root of the project
+    const responsiveReducer = Object.keys(storeState).reduce((prev, current) => (
+        // if the reducer contains the responsive state marker then keep it
+        storeState[current]._responsiveState ? current : prev
+    // otherwise the value should be at least falsey
+    ), false)
+
+    // if we couldn't find a responsive reducer at the root of the project
+    // if (!responsiveReducer) {
+    //     throw {
+    //         name: 'Responsive State Error',
+    //         message: 'Could not find responsive state reducer - Performance mode can only '
+    //                  + 'be used if the responsive reducer is at the root of your reducer tree.'
+    //     }
+    // }
+
+    // get the object of breakpoints
+    const breakpoints = storeState[responsiveReducer].breakpoints
+
+    // get the object of media queries
+    const mediaQueries = MediaQuery.asObject(breakpoints)
+
+    // for every breakpoint range
+    for (const breakpoint of Object.keys(mediaQueries)) {
+
+        // if we are looking at a non-valued breakpoint (like infinity)
+        if (!breakpoints[breakpoint]) {
+            continue
+        }
+
+        // create a media query list
+        const mediaQueryList = window.matchMedia(mediaQueries[breakpoint])
+
+        /* eslint-disable no-loop-func */
+
+        // whenever any of the media query lists status changes
+        mediaQueryList.addListener((query) => {
+            // if its a match
+            if (query.matches) {
+                console.log('updated media query match')
+                // recaulate the state
+                refreshResponsiveState()
+            }
+        })
+
+        /* eslint-enable no-loop-func */
+    }
+
+    // if we are supposed to calculate the initial state
+    if (calculateStateInitially) {
+        // then do so
+        refreshResponsiveState()
+    }
+}

--- a/src/util/addPerformanceModeHandlers.js
+++ b/src/util/addPerformanceModeHandlers.js
@@ -24,38 +24,29 @@ export default ({store, window, calculateStateInitially}) => {
     ), false)
 
     // if we couldn't find a responsive reducer at the root of the project
-    // if (!responsiveReducer) {
-    //     throw {
-    //         name: 'Responsive State Error',
-    //         message: 'Could not find responsive state reducer - Performance mode can only '
-    //                  + 'be used if the responsive reducer is at the root of your reducer tree.'
-    //     }
-    // }
+    if (!responsiveReducer) {
+        throw new Error(
+            'Could not find responsive state reducer - Performance mode can only '
+            + 'be used if the responsive reducer is at the root of your reducer tree.'
+        )
+    }
 
     // get the object of breakpoints
     const breakpoints = storeState[responsiveReducer].breakpoints
-
     // get the object of media queries
     const mediaQueries = MediaQuery.asObject(breakpoints)
 
     // for every breakpoint range
     for (const breakpoint of Object.keys(mediaQueries)) {
-
-        // if we are looking at a non-valued breakpoint (like infinity)
-        if (!breakpoints[breakpoint]) {
-            continue
-        }
-
-        // create a media query list
+        // create a media query list for the breakpoint
         const mediaQueryList = window.matchMedia(mediaQueries[breakpoint])
 
         /* eslint-disable no-loop-func */
 
         // whenever any of the media query lists status changes
         mediaQueryList.addListener((query) => {
-            // if its a match
+            // if a new query was matched
             if (query.matches) {
-                console.log('updated media query match')
                 // recaulate the state
                 refreshResponsiveState()
             }

--- a/src/util/addThrottledHandlers.js
+++ b/src/util/addThrottledHandlers.js
@@ -1,0 +1,20 @@
+// third party imports
+import throttle from 'lodash/throttle'
+// local imports
+import calculateResponsiveState from '../actions/creators/calculateResponsiveState'
+
+// this function adds throttled responsive handlers to the window
+export default ({store, window, throttleTime, calculateStateInitially}) => {
+    // throttled event handler for window resize
+    const throttledHandler = throttle(
+        // just dispatch action to calculate responsive state
+        () => store.dispatch(calculateResponsiveState(window)),
+        throttleTime
+    )
+    // initialize the responsive state
+    if (calculateStateInitially) {
+        throttledHandler()
+    }
+    // add the resize event listener
+    window.addEventListener('resize', throttledHandler)
+}

--- a/src/util/createResponsiveStateReducer.js
+++ b/src/util/createResponsiveStateReducer.js
@@ -127,6 +127,7 @@ export default (breakpoints = defaultBreakpoints) => {
             const orientation = getOrientation(matchMedia)
             // return calculated state
             return {
+                _responsiveState: true,
                 width: innerWidth,
                 height: innerHeight,
                 lessThan: getLessThan(innerWidth, breakpoints, mediaType),

--- a/src/util/createResponsiveStoreEnhancer.js
+++ b/src/util/createResponsiveStoreEnhancer.js
@@ -20,6 +20,6 @@ export default ({throttleTime = 100, calculateStateInitially = true, performance
             addEventHandlers(createStore(...args), {
                 throttleTime,
                 calculateStateInitially,
-                performanceMode
+                performanceMode,
             })
 }

--- a/src/util/createResponsiveStoreEnhancer.js
+++ b/src/util/createResponsiveStoreEnhancer.js
@@ -11,11 +11,15 @@ import addEventHandlers from './addEventHandlers'
  * @returns {function} - The store enhancer (which adds event listeners to
  * dispatch actions on window resize).
  */
-export default ({throttleTime = 100, calculateStateInitially = true} = {}) => {
+export default ({throttleTime = 100, calculateStateInitially = true, performanceMode = false} = {}) => {
     // return store enhancer
     return (createStore) =>
         // return enhanced version of `createStore`
         (...args) =>
             // return store after adding event handlers
-            addEventHandlers(createStore(...args), {throttleTime, calculateStateInitially})
+            addEventHandlers(createStore(...args), {
+                throttleTime,
+                calculateStateInitially,
+                performanceMode
+            })
 }


### PR DESCRIPTION
This PR adds the `performanceMode` flag to the store enhancer which limits the re-calculation of the responsive state to only when the state actually changes - resolving #22. After this feature has been tested for a comfortable amount of time, I plan to remove the browser height/width from the responsive state as well as the throttled handlers since the overall experience should be the same.

For more information see: https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries#Browser_compatibility

cc: @EloB @AcidicX @jsjaspreet