### PR TITLE
Use documentElement.clientWidth instead of window.innerWidth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "redux-responsive",
+  "name": "redux-responsive-pistol-pete",
   "version": "3.1.5",
   "description": "Utilities for easily creating responsive designs in a redux architecture.",
   "main": "index.js",

--- a/src/actions/creators/calculateResponsiveState.js
+++ b/src/actions/creators/calculateResponsiveState.js
@@ -7,8 +7,6 @@ import {CALCULATE_RESPONSIVE_STATE} from '../types'
  * responsive state.
  * @arg {object} window - Any window-like object (has keys `innerWidth` and
  * `matchMedia`).
- * @arg {number} window.innerWidth - The value for the browser width (to pass to
- * the responsive state reducer logic).  See browser global `window.innerWidth`.
  * @arg {function} window.matchMedia - The method with which to match media
  * queries (to pass to the responsive sate reducer logic).  See global
  * `window.matchMedia`.
@@ -16,9 +14,8 @@ import {CALCULATE_RESPONSIVE_STATE} from '../types'
  * `CALCULATE_RESPONSIVE_STATE`, and will be directly given the two keys taken
  * from the `window` argument.
  */
-export default ({innerWidth, innerHeight, matchMedia} = {}) => ({
+export default ({innerHeight, matchMedia} = {}) => ({
     type: CALCULATE_RESPONSIVE_STATE,
-    //innerWidth,
     innerWidth: document.documentElement.clientWidth,
     innerHeight,
     matchMedia,

--- a/src/actions/creators/calculateResponsiveState.js
+++ b/src/actions/creators/calculateResponsiveState.js
@@ -18,7 +18,8 @@ import {CALCULATE_RESPONSIVE_STATE} from '../types'
  */
 export default ({innerWidth, innerHeight, matchMedia} = {}) => ({
     type: CALCULATE_RESPONSIVE_STATE,
-    innerWidth,
+    //innerWidth,
+    innerWidth: document.documentElement.clientWidth,
     innerHeight,
     matchMedia,
 })

--- a/tests/test_calculateResponsiveState.js
+++ b/tests/test_calculateResponsiveState.js
@@ -25,11 +25,10 @@ describe('calculateResponsiveState', function () {
 
 
     it('returns action object with correct type when window-like arg passed', function () {
-        const innerWidth = 100
         const innerHeight = 200
         const matchMedia = function () {}
 
-        const action = calculateResponsiveState({innerWidth, innerHeight, matchMedia})
+        const action = calculateResponsiveState({innerHeight, matchMedia})
 
         // action should be an object
         expect(action).to.be.an('object')
@@ -39,16 +38,15 @@ describe('calculateResponsiveState', function () {
 
 
     it('puts the argument properties onto the returned action', function () {
-        const innerWidth = Math.ceil(100 * Math.random())
         const innerHeight = Math.ceil(100 * Math.random())
         const matchMedia = function () {
             return Math.random() * Math.random()
         }
 
-        const action = calculateResponsiveState({innerWidth, innerHeight, matchMedia})
+        const action = calculateResponsiveState({innerHeight, matchMedia})
 
         // action should have same properties as passed to creator
-        expect(action.innerWidth).to.equal(innerWidth)
+        expect(action.innerWidth).to.equal(document.documentElement.clientWidth)
         expect(action.innerHeight).to.equal(innerHeight)
         expect(action.matchMedia).to.equal(matchMedia)
     })
@@ -57,7 +55,7 @@ describe('calculateResponsiveState', function () {
     it('properly defaults when no arg passed', function () {
         const action = calculateResponsiveState()
 
-        expect(action.innerWidth).to.be.undefined
+        expect(action.innerWidth).to.equal(document.documentElement.clientWidth)
         expect(action.innerHeight).to.be.undefined
         expect(action.matchMedia).to.be.undefined
     })
@@ -66,7 +64,7 @@ describe('calculateResponsiveState', function () {
     it('properly defaults when empty arg passed', function () {
         const action = calculateResponsiveState({})
 
-        expect(action.innerWidth).to.be.undefined
+        expect(action.innerWidth).to.equal(document.documentElement.clientWidth)
         expect(action.innerHeight).to.be.undefined
         expect(action.matchMedia).to.be.undefined
     })


### PR DESCRIPTION
You'll have to change the npm package name back. 

Fixes issues with pinch to zoom using maximum-scale and user-scalable=yes meta tag. I'm not sure whether this will break it for other users as this seems to me like a fundamental change to the source of the width attribute. Maybe this should be made into another mode?



