### PR TITLE
Fix immutable state support for performance mode #56

### DIFF
--- a/src/util/addPerformanceModeHandlers.js
+++ b/src/util/addPerformanceModeHandlers.js
@@ -38,7 +38,7 @@ export default ({store, window, calculateStateInitially}) => {
     }
 
     // get the object of breakpoints
-    const breakpoints = storeState[responsiveStateKey].breakpoints
+    const breakpoints = storeState['@@__IMMUTABLE_ITERABLE__@@'] ? storeState.get(responsiveStateKey).breakpoints : storeState[responsiveStateKey].breakpoints
     // get the object of media queries
     const mediaQueries = MediaQuery.asObject(breakpoints)
 


### PR DESCRIPTION
Just tired `3.2.1` with the pull request #56  merged and I have an issue with using a immutable state.

As I am using immutablejs for my state and custom breakpoints. I am still having issues with this. It correctly finds that I have `browser` in my immutablejs state.

But when it tries to get the breakpoints. 

[`const breakpoints = storeState[responsiveStateKey].breakpoints`](https://github.com/AlecAivazis/redux-responsive/blob/45818b901ae61f37ce308982ce7204c6a08b32e6/src/util/addPerformanceModeHandlers.js#L41)

It errors out. Should it not be

`const breakpoints = storeState['@@__IMMUTABLE_ITERABLE__@@'] ? storeState.get(responsiveStateKey).breakpoints : storeState[responsiveStateKey].breakpoints`