### PR TITLE
Check for specific prop of window before adding window handlers

### DIFF
--- a/src/util/createResponsiveStoreEnhancer.js
+++ b/src/util/createResponsiveStoreEnhancer.js
@@ -16,7 +16,7 @@ export default ({ calculateInitialState = true } = {}) => {
         const store = createStore(...args)
 
         // if there is a `window`
-        if (typeof window !== 'undefined') {
+        if (typeof window !== 'undefined' && typeof window.matchMedia !== 'undefined') {
             // add the handlers that only fire when the responsive state changes
             addPerformanceModeHandlers({store, window, calculateInitialState})
         }


### PR DESCRIPTION
Allows for webpack static builds where a dummy window object is present (eg static-site-generator-webpack-plugin).