### PR TITLE
Refactor/small bundle - fixes #76

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,10 +1,13 @@
 // external imports
 import React from 'react'
+import { connect } from 'react-redux'
 import { StyleSheet } from '../src/react'
 
-const App = ({styles}) => (
+const App = ({styles, browser}) => (
     <div style={styles.container}>
         hello world
+        <br/>
+        {JSON.stringify(browser)}
     </div>
 )
 
@@ -17,4 +20,5 @@ const stylesheet = {
     },
 }
 
-export default StyleSheet(stylesheet)(App)
+const selector = ({browser}) => ({browser})
+export default StyleSheet(stylesheet)(connect(selector)(App))

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash.mapvalues": "^4.6.0",
     "mediaquery": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "dependencies": {
     "lodash.mapvalues": "^4.6.0",
-    "lodash.sortby": "^4.7.0",
     "mediaquery": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.3.0",
   "description": "Utilities for easily creating responsive designs in a redux architecture.",
   "main": "index.js",
+  "module": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/aaivazis/redux-responsive.git"
@@ -12,9 +13,10 @@
     "build": "webpack --config config/webpack.js",
     "build:prod": "NODE_ENV=production npm run build",
     "build:lib": "babel src --out-dir lib",
+    "build:all": "npm run build && npm run build:prod && npm run build:lib",
     "clean": "rm -rf react.* index.* lib/",
     "dev": "NODE_ENV=dev webpack-dev-server --inline --hot --config  example/webpack.js",
-    "prepublish": "npm run build && npm run build:prod && npm run build:lib",
+    "prepublish": "npm run build:all",
     "test": "NODE_ENV=test jest",
     "test:watch": "npm run test -- --watch",
     "test:coverage": "npm run test -- --coverage",
@@ -22,7 +24,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.2.1",
+    "lodash.mapvalues": "^4.6.0",
+    "lodash.sortby": "^4.7.0",
     "mediaquery": "0.0.3"
   },
   "devDependencies": {

--- a/src/react/components/stylesheet.js
+++ b/src/react/components/stylesheet.js
@@ -1,7 +1,6 @@
 // external imports
 // import {connect} from 'react-redux'
 import mapValues from 'lodash.mapvalues'
-import sortBy from 'lodash.sortby'
 
 /*
  styles are passed as objects with the following form:
@@ -47,13 +46,13 @@ export const browserMatches = (browser, pattern) => {
 // this function sorts the style keys so they are applied in the correct order
 // for less than criteria, the styles are sorted highest to lowest
 // for greater than criteria, the styles are storted lowest to highest
-export const sortKeys = (keys, breakpoints) => (
+export const sortKeys = (keys, breakpoints) => {
     // sort the keys
-    sortBy(keys, (key) => {
+    const mapped = keys.map(key => {
         // if the key is a custom style
         if (key[0] !== '_') {
             // deal with it first
-            return 0
+            return {key, sort: 0}
         }
         // otherwise the key is a responsive style
 
@@ -77,9 +76,11 @@ export const sortKeys = (keys, breakpoints) => (
         }
 
         // return the sort index
-        return sortValue
+        return {key, sort: sortValue}
     })
-)
+
+    return mapped.sort(({sort: sortA}, {sort: sortB}) => sortA - sortB).map(({key}) => key)
+}
 
 // this function takes the current state of the browser and
 // returns a function that creates a stylesheet to match

--- a/src/react/components/stylesheet.js
+++ b/src/react/components/stylesheet.js
@@ -1,7 +1,7 @@
 // external imports
 // import {connect} from 'react-redux'
-import mapValues from 'lodash/mapValues'
-import sortBy from 'lodash/sortBy'
+import mapValues from 'lodash.mapvalues'
+import sortBy from 'lodash.sortby'
 
 /*
  styles are passed as objects with the following form:

--- a/src/react/components/stylesheet.js
+++ b/src/react/components/stylesheet.js
@@ -1,6 +1,4 @@
 // external imports
-// import {connect} from 'react-redux'
-import mapValues from 'lodash.mapvalues'
 
 /*
  styles are passed as objects with the following form:
@@ -121,8 +119,16 @@ export const mapStateToPropsFactory = (stylesheet, {reducerName} = defaultOption
     // if we are passed a functional stylesheet, hand it the component props, otherwise just use the object
     const sheet = typeof stylesheet === 'function' ? stylesheet(browser, props) : stylesheet
 
+    // the function to mutate values
+    const transformValue = transformStyle(browser)
+
     // the stylesheet only differs by values of
-    return {styles: mapValues(sheet, transformStyle(browser))}
+    return {
+        styles: Object.keys(sheet).reduce((prev, key) => ({
+            ...prev,
+            [key]: transformValue(sheet[key]),
+        }), {}),
+    }
 }
 
 // the default options

--- a/src/react/components/stylesheet.test.js
+++ b/src/react/components/stylesheet.test.js
@@ -7,6 +7,7 @@ import {
     browserMatches,
     sortKeys,
     transformStyle,
+    mapStateToPropsFactory,
 } from './stylesheet'
 
 describe('ReactStyleSheet', function () {
@@ -66,6 +67,48 @@ describe('ReactStyleSheet', function () {
             '_greaterThan_large',
             '_equal_medium',
         ])
+    })
+
+    test('can transform an entire stylesheet', function() {
+        // the mocked browser state
+        const browser = {
+            greaterThan: {
+                medium: true,
+                large: false,
+            },
+            lessThan: {
+                medium: false,
+                large: true,
+            },
+            mediaType: 'large',
+            breakpoints: ['medium', 'large']
+        }
+        // the stylesheet
+        const baseValue = 'black'
+        const greaterThanValue = 'blue'
+        const lessThanValue = 'green'
+
+        const style = {
+            'border': baseValue,
+            '_greaterThan_medium': {
+                'border': greaterThanValue,
+            },
+            '_lessThan_large': {
+                'border': lessThanValue,
+            }
+        }
+        const sheet = {
+            style1: style,
+            style2: style,
+        }
+
+        const { styles } = mapStateToPropsFactory(sheet)({browser})
+
+        // sanity check
+        expect(styles.style1).toBeDefined()
+        // make sure the stylesheet is what we expect
+        expect(styles.style1.border).toBe(lessThanValue)
+        expect(styles.style2.border).toBe(lessThanValue)
     })
 
 

--- a/src/util/createEnhancer.test.js
+++ b/src/util/createEnhancer.test.js
@@ -1,5 +1,4 @@
 // third party imports
-import isFunction from 'lodash/isFunction'
 import sinon from 'sinon'
 // local imports
 import createEnhancer from './createEnhancer'
@@ -8,11 +7,11 @@ import {defaultBreakpoints} from './createReducer'
 
 describe('createEnhancer', function () {
     it('returns a function when given an options object', function () {
-        expect(isFunction(createEnhancer({}))).toBe(true)
+        expect(typeof createEnhancer({})).toBe('function')
     })
 
     it('returns a function when not given any options', function () {
-        expect(isFunction(createEnhancer())).toBe(true)
+        expect(typeof createEnhancer()).toBe('function')
     })
 
     describe('the returned store enhancer', function () {
@@ -23,7 +22,7 @@ describe('createEnhancer', function () {
         })
 
         it('returns a function', function () {
-            expect(isFunction(enhancer())).toBe(true)
+            expect(typeof enhancer()).toBe('function')
         })
 
         describe('the returned (enhanced) `createStore`', function () {

--- a/src/util/createReducer.js
+++ b/src/util/createReducer.js
@@ -19,10 +19,10 @@ const defaultOrientation = null
 // a lightweight version of lodash.transform
 const transform = (obj, f) => {
     // a place to mutate
-    let internal = {}
+    const internal = {}
     // basically we have to reduce the keys down to an object and pass the k/v pairs to each f
     Object.keys(obj).forEach(key => f(internal, obj[key], key))
-    //r eturn the object we've been building up
+    // return the object we've been building up
     return internal
 }
 

--- a/src/util/createReducer.js
+++ b/src/util/createReducer.js
@@ -1,7 +1,5 @@
 // third party imports
 import MediaQuery from 'mediaquery'
-import transform from 'lodash/transform'
-import reduce from 'lodash/reduce'
 // local imports
 import CALCULATE_RESPONSIVE_STATE from '../actions/types/CALCULATE_RESPONSIVE_STATE'
 
@@ -17,6 +15,16 @@ export const defaultBreakpoints = {
 const defaultMediaType = 'infinity'
 // orientation to default to when no `window` present
 const defaultOrientation = null
+
+// a lightweight version of lodash.transform
+const transform = (obj, f) => {
+    // a place to mutate
+    let internal = {}
+    // basically we have to reduce the keys down to an object and pass the k/v pairs to each f
+    Object.keys(obj).forEach(key => f(internal, obj[key], key))
+    //r eturn the object we've been building up
+    return internal
+}
 
 
 /**
@@ -48,6 +56,7 @@ export function getOrderMap(bps) {
     return transform(bps, (result, breakpoint, mediaType) => {
         // figure out the index of the mediatype
         const index = keys.indexOf(mediaType)
+
         // if there is an entry in the sort for this
         if (index !== -1) {
             // to its index in the sorted list
@@ -143,9 +152,9 @@ function getMediaType(matchMedia, mediaQueries, infinityMediaType) {
     }
 
     // there is a window, so compute the true media type
-    return reduce(mediaQueries, (result, query, type) => {
+    return Object.keys(mediaQueries).reduce((result, query) => {
         // return the new type if the query matches otherwise the previous one
-        return matchMedia(query).matches ? type : result
+        return matchMedia(mediaQueries[query]).matches ? mediaQueries[query] : result
     // use the infinity media type
     }, infinityMediaType)
 }
@@ -170,9 +179,9 @@ function getOrientation(matchMedia) {
     }
 
     // there is a window, so compute the true orientation
-    return reduce(mediaQueries, (result, query, type) => {
+    return Object.keys(mediaQueries).reduce((result, query) => {
         // return the new type if the query matches otherwise the previous one
-        return matchMedia(query).matches ? type : result
+        return matchMedia(mediaQueries[query]).matches ? mediaQueries[query] : result
     // use the default orientation
     }, defaultOrientation)
 }

--- a/src/util/createReducer.js
+++ b/src/util/createReducer.js
@@ -154,7 +154,7 @@ function getMediaType(matchMedia, mediaQueries, infinityMediaType) {
     // there is a window, so compute the true media type
     return Object.keys(mediaQueries).reduce((result, query) => {
         // return the new type if the query matches otherwise the previous one
-        return matchMedia(mediaQueries[query]).matches ? mediaQueries[query] : result
+        return matchMedia(mediaQueries[query]).matches ? query : result
     // use the infinity media type
     }, infinityMediaType)
 }

--- a/src/util/createReducer.test.js
+++ b/src/util/createReducer.test.js
@@ -1,5 +1,4 @@
 // third party imports
-import isFunction from 'lodash/isFunction'
 import { createStore } from 'redux'
 import { combineReducers as immutableCombine } from 'redux-immutablejs'
 // local imports
@@ -34,7 +33,7 @@ describe('createReducer', function () {
 
 
         it('returns a function', function () {
-            expect(isFunction(reducer)).toBe(true)
+            expect(typeof reducer).toBe('function')
         })
     })
 
@@ -72,7 +71,7 @@ describe('createReducer', function () {
 
 
             it('is a function', function () {
-                expect(isFunction(reducer)).toBe(true)
+                expect(typeof reducer).toBe('function')
             })
 
 

--- a/src/util/getBreakpoints.test.js
+++ b/src/util/getBreakpoints.test.js
@@ -1,5 +1,4 @@
 // third party imports
-import isFunction from 'lodash/isFunction'
 import {createStore, combineReducers} from 'redux'
 import { combineReducers as immutableCombine } from 'redux-immutablejs'
 // local imports

--- a/src/util/handlers.test.js
+++ b/src/util/handlers.test.js
@@ -10,7 +10,7 @@ const Reducer = createReducer()
 
 
 describe('PerformanceMode handlers', function () {
-    it('calcuates the initial state by default', function() {
+    it('calculates the initial state by default', function() {
         // create a store with the default behavior
         const reducer = combineReducers({
             browser: Reducer,
@@ -19,11 +19,11 @@ describe('PerformanceMode handlers', function () {
         // add a matchMedia mock for this test
         window.matchMedia = matchMediaMock.create()
         window.matchMedia.setConfig({type: "screen", width: 500})
-
         // create an enhancer with the current value of the window
         const enhancer = createEnhancer()
         // create the enhanced store
         const store = createStore(reducer, enhancer)
+
         // get the current state of the browser
         const {browser} = store.getState()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,10 +3504,6 @@ lodash.keysin@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash.mapvalues@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
-
 lodash.merge@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-3.3.2.tgz#0d90d93ed637b1878437bb3e21601260d7afe994"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,10 +3541,6 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
-lodash.sortby@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-
 lodash.template@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3504,6 +3504,10 @@ lodash.keysin@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.mapvalues@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
+
 lodash.merge@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-3.3.2.tgz#0d90d93ed637b1878437bb3e21601260d7afe994"
@@ -3536,6 +3540,10 @@ lodash.omit@^3.1.0:
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
 lodash.template@^3.0.0:
   version "3.6.2"
@@ -4568,7 +4576,7 @@ request-progress@~2.0.1:
   dependencies:
     throttleit "^1.0.0"
 
-request@2.79.0, request@^2.79.0, request@~2.79.0:
+request@2.79.0, request@~2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -4593,7 +4601,7 @@ request@2.79.0, request@^2.79.0, request@~2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-request@^2.81.0:
+request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:


### PR DESCRIPTION
This PR reduces the final bundle size from 150kb (which was a bit obscene, to be honest) to 25.8kb by removing the dependency on lodash. All of tests pass and the example stylesheet works as expected.

@bradbirnbaum - thanks for bringing this up!