### PR TITLE
Improved tests for usage with redux-immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,11 @@ const component = StyleSheet(stylesheet)(({styles}) => (
 ```
 
 
+## redux-immutable
+This library supports using [redux-immutable](https://www.npmjs.com/package/redux-immutable) to make the **root** of your state an Immutable.js Map or Record.
+
+However, transforming the branch of state managed by `redux-responsive` into Immutable data is not supported, because the `redux-responsive` reducer expects vanilla JS. Please keep this in mind if you're using SSR and transforming your state before hydrating.
+
 ## Versioning
 
 [Semver](http://semver.org/) is followed as closely as possible. For updates and migration instructions, see the [changelog](https://github.com/AlecAivazis/redux-responsive/wiki/Changelog).

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-hot-loader": "next",
     "react-redux": "^5.0.4",
     "redux": "^3.6.0",
-    "redux-immutablejs": "^0.0.8",
+    "redux-immutable": "^4.0.0",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
     "vinyl-named": "^1.1.0",

--- a/src/util/createReducer.test.js
+++ b/src/util/createReducer.test.js
@@ -1,6 +1,7 @@
 // third party imports
 import { createStore } from 'redux'
-import { combineReducers as immutableCombine } from 'redux-immutablejs'
+import { combineReducers as immutableCombine } from 'redux-immutable'
+import { Record } from 'immutable'
 // local imports
 import createReducer, {
     computeOrder,
@@ -140,7 +141,7 @@ describe('createReducer', function () {
             expect(store.getState().lessThan).toEqual(expectedLessThan)
         })
 
-        it('correctly injects initialMediaType into immutable reducer', function() {
+        it('correctly injects initialMediaType into immutable (Map) root state', function() {
             // create a reducer with the initial state
             const reducer = createReducer(breakpoints, {
                 initialMediaType: 'small',
@@ -150,6 +151,33 @@ describe('createReducer', function () {
             const store = createStore(immutableCombine({
                 browser: reducer
             }))
+
+            // the expected value for the lessThan object
+            const expectedLessThan = {
+                small: false,
+                medium: true,
+                large: true,
+                infinity: true,
+            }
+
+            // make sure we were able to correctly inject the initial state
+            expect(store.getState().get('browser').lessThan).toEqual(expectedLessThan)
+        })
+
+        it('correctly injects initialMediaType into immutable (Record) root state', function() {
+            // create a reducer with the initial state
+            const reducer = createReducer(breakpoints, {
+                initialMediaType: 'small',
+            })
+
+            const StateRecord = Record({
+              browser: undefined
+            })
+
+            // create a redux store with the reducer
+            const store = createStore(immutableCombine({
+                browser: reducer
+            }, StateRecord))
 
             // the expected value for the lessThan object
             const expectedLessThan = {

--- a/src/util/getBreakpoints.test.js
+++ b/src/util/getBreakpoints.test.js
@@ -20,7 +20,7 @@ describe('Breakpoint discovery', function () {
     })
 
 
-    it('Can responsive state in find Immutable.js Map root state', function() {
+    it('Can find responsive state in Immutable.js Map root state', function() {
         // create a redux store with the reducer at the root
         const store = createStore(immutableCombine({
             browser: reducer
@@ -31,7 +31,7 @@ describe('Breakpoint discovery', function () {
     })
 
 
-    it('Can responsive state in find Immutable.js Record root state', function() {
+    it('Can find responsive state in Immutable.js Record root state', function() {
         const StateRecord = Record({
           browser: undefined
         })

--- a/src/util/getBreakpoints.test.js
+++ b/src/util/getBreakpoints.test.js
@@ -1,6 +1,7 @@
 // third party imports
 import {createStore, combineReducers} from 'redux'
-import { combineReducers as immutableCombine } from 'redux-immutablejs'
+import { combineReducers as immutableCombine } from 'redux-immutable'
+import { Record } from 'immutable'
 // local imports
 import getBreakpoints from './getBreakpoints'
 import createReducer, {defaultBreakpoints} from './createReducer'
@@ -19,11 +20,25 @@ describe('Breakpoint discovery', function () {
     })
 
 
-    it('Can find immutable js reducers', function() {
+    it('Can responsive state in find Immutable.js Map root state', function() {
         // create a redux store with the reducer at the root
         const store = createStore(immutableCombine({
             browser: reducer
         }))
+
+        // make sure we could retrieve the default breakpoints from the store
+        expect(getBreakpoints(store)).toBe(defaultBreakpoints)
+    })
+
+
+    it('Can responsive state in find Immutable.js Record root state', function() {
+        const StateRecord = Record({
+          browser: undefined
+        })
+        // create a redux store with the reducer at the root
+        const store = createStore(immutableCombine({
+            browser: reducer
+        }, StateRecord))
 
         // make sure we could retrieve the default breakpoints from the store
         expect(getBreakpoints(store)).toBe(defaultBreakpoints)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4472,9 +4472,9 @@ redbox-react@^1.2.5:
     object-assign "^4.0.1"
     prop-types "^15.5.4"
 
-redux-immutablejs@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/redux-immutablejs/-/redux-immutablejs-0.0.8.tgz#2c173dac1aaebfb20ec86e076b7e2ce65f487a41"
+redux-immutable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redux-immutable/-/redux-immutable-4.0.0.tgz#3a1a32df66366462b63691f0e1dc35e472bbc9f3"
 
 redux@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
(I originally thought I'd need to adjust `getBreakpoints.js` in order to address #83, but found that it was actually working as-is, so this PR doesn't make any implementation changes)

Previous tests were using `redux-immutablejs` - I replaced that with `redux-immutable`, which is much more popular.

I also added a couple new tests specifically for `redux-immutable`'s option to use an `Immutable.Record` for the state root (in addition to the existing tests that use its default setting of an `Immutable.Map` state root). Both of these tests are already passing, so no changes to the implementation were needed.

Finally, I updated the readme to add a little note about using `redux-immutable`.