### PR TITLE
Implement embedding the reducer anywhere in the state

### DIFF
--- a/src/util/getBreakpoints.js
+++ b/src/util/getBreakpoints.js
@@ -1,38 +1,76 @@
 /**
+ * Returns the value found in obj at path. Delegates to obj.getIn if available.
+ * @param obj
+ * @param path
+ * @returns {*}
+ */
+function getIn(obj, path) {
+    if (obj.getIn) {
+        return obj.getIn(path);
+    }
+    return path.reduce((accum, next) => accum[next], obj);
+}
+
+/**
+ * Returns all keys of an object. Delegates to either obj.keys or Object.keys.
+ * @param obj
+ * @returns {*}
+ */
+
+function keys(obj) {
+    if (obj.keys) {
+        return Array.from(obj.keys());
+    }
+    return Object.keys(obj);
+}
+
+/**
+ * An implementation of breadth-first search. Looks for marker key in the tree.
+ * @param tree
+ * @param marker
+ * @param [maxDepth]
+ * @returns {*}
+ */
+function findMarker(tree, marker, maxDepth = 20) {
+    const rootPath = [];
+    let queue = [rootPath];
+    while (queue.length > 0) {
+        let currentPath = queue.shift();
+        if (currentPath.length > maxDepth) {
+            continue;
+        }
+        let currentObj = getIn(tree, currentPath);
+        if (currentObj[marker]) {
+            return currentPath;
+        }
+        keys(currentObj).forEach(k => {
+            queue.push(currentPath.concat(k));
+        });
+    }
+    return false;
+}
+
+/**
  * Searches through the given redux store and returns the breakpoints found inside.
  * @arg {object} - The redux state.
  * @returns {object} - The breakpoints associated with the responsive state inside the store.
  */
 function getBreakpoints(store) {
-// grab the current state of the store
+    // grab the current state of the store
     const storeState = store.getState()
 
-    let responsiveStateKey
-    // if the redux state root is an Immutable.js Iterable
-    if (storeState['@@__IMMUTABLE_ITERABLE__@@'] === true) {
-        responsiveStateKey = storeState.findKey(stateBranch => stateBranch._responsiveState)
-    } else {
-        // go through every reducer at the root of the project
-        responsiveStateKey = Object.keys(storeState).reduce((prev, current) => (
-            // if the reducer contains the responsive state marker then keep it
-            storeState[current] && storeState[current]._responsiveState ? current : prev
-        // otherwise the value should be at least falsey
-        ), false)
-    }
+    let responsiveStatePath = findMarker(storeState, '_responsiveState');
 
     // if we couldn't find a responsive reducer at the root of the project
-    if (!responsiveStateKey) {
+    if (!responsiveStatePath) {
         throw new Error(
-            'Could not find responsive state reducer. Currently, redux-responsive can only'
-            + 'be used if the responsive reducer is at the root of your reducer tree.'
+            'Could not find responsive state reducer. '
             + 'If you are still running into trouble, please open a ticket on github.'
         )
     }
 
     // return the breakpoints in the redux store
-    return storeState['@@__IMMUTABLE_ITERABLE__@@']
-            ? storeState.get(responsiveStateKey).breakpoints
-            : storeState[responsiveStateKey].breakpoints
+    return getIn(storeState, responsiveStatePath).breakpoints;
 }
 
 export default getBreakpoints

--- a/src/util/getBreakpoints.js
+++ b/src/util/getBreakpoints.js
@@ -40,10 +40,12 @@ function findMarker(tree, marker, maxDepth = 20) {
             continue
         }
         const currentObj = getIn(tree, currentPath)
-        if (currentObj[marker]) {
-            return currentPath
+        if (currentObj) {
+            if (currentObj[marker]) {
+                return currentPath
+            }
+            queue.push(...keys(currentObj).map(k => currentPath.concat(k)))
         }
-        queue.push(...keys(currentObj).map(k => currentPath.concat(k)))
     }
     return false
 }

--- a/src/util/getBreakpoints.js
+++ b/src/util/getBreakpoints.js
@@ -6,9 +6,9 @@
  */
 function getIn(obj, path) {
     if (obj.getIn) {
-        return obj.getIn(path);
+        return obj.getIn(path)
     }
-    return path.reduce((accum, next) => accum[next], obj);
+    return path.reduce((accum, next) => accum[next], obj)
 }
 
 /**
@@ -19,9 +19,9 @@ function getIn(obj, path) {
 
 function keys(obj) {
     if (obj.keys) {
-        return Array.from(obj.keys());
+        return Array.from(obj.keys())
     }
-    return Object.keys(obj);
+    return Object.keys(obj)
 }
 
 /**
@@ -32,22 +32,20 @@ function keys(obj) {
  * @returns {*}
  */
 function findMarker(tree, marker, maxDepth = 20) {
-    const rootPath = [];
-    let queue = [rootPath];
+    const rootPath = []
+    const queue = [rootPath]
     while (queue.length > 0) {
-        let currentPath = queue.shift();
+        const currentPath = queue.shift()
         if (currentPath.length > maxDepth) {
-            continue;
+            continue
         }
-        let currentObj = getIn(tree, currentPath);
+        const currentObj = getIn(tree, currentPath)
         if (currentObj[marker]) {
-            return currentPath;
+            return currentPath
         }
-        keys(currentObj).forEach(k => {
-            queue.push(currentPath.concat(k));
-        });
+        queue.push(...keys(currentObj).map(k => currentPath.concat(k)))
     }
-    return false;
+    return false
 }
 
 /**
@@ -59,7 +57,7 @@ function getBreakpoints(store) {
     // grab the current state of the store
     const storeState = store.getState()
 
-    let responsiveStatePath = findMarker(storeState, '_responsiveState');
+    const responsiveStatePath = findMarker(storeState, '_responsiveState')
 
     // if we couldn't find a responsive reducer at the root of the project
     if (!responsiveStatePath) {
@@ -70,7 +68,7 @@ function getBreakpoints(store) {
     }
 
     // return the breakpoints in the redux store
-    return getIn(storeState, responsiveStatePath).breakpoints;
+    return getIn(storeState, responsiveStatePath).breakpoints
 }
 
 export default getBreakpoints

--- a/src/util/getBreakpoints.test.js
+++ b/src/util/getBreakpoints.test.js
@@ -44,6 +44,50 @@ describe('Breakpoint discovery', function () {
         expect(getBreakpoints(store)).toBe(defaultBreakpoints)
     })
 
+    it('Can find responsive state anywhere in the state', function() {
+        const store = createStore(combineReducers({
+            foo: combineReducers({
+                bar: combineReducers({
+                    baz: reducer
+                }),
+                quux: () => true,
+            })
+        }));
+        expect(getBreakpoints(store)).toBe(defaultBreakpoints);
+    })
+
+    it('Can find responsive state anywhere in the ImmutableJS Map', function() {
+        const store = createStore(immutableCombine({
+            foo: immutableCombine({
+                bar: immutableCombine({
+                    baz: reducer
+                }),
+                quux: () => true,
+            })
+        }));
+        expect(getBreakpoints(store)).toBe(defaultBreakpoints);
+    })
+
+
+    it('Can find responsive state anywhere in the ImmutableJS Record', function() {
+        const StateRecord = Record({
+            foo: Record({
+                bar: Record({
+                    baz: undefined,
+                })(),
+                quux: true,
+            })()
+        });
+        const store = createStore(immutableCombine({
+            foo: immutableCombine({
+                bar: immutableCombine({
+                    baz: reducer
+                }),
+                quux: () => true,
+            })
+        }, StateRecord));
+        expect(getBreakpoints(store)).toBe(defaultBreakpoints);
+    })
 
     it('Complains if it cannot find a reducer at root', function() {
         // create a store without the reducer at reducer

--- a/src/util/getBreakpoints.test.js
+++ b/src/util/getBreakpoints.test.js
@@ -52,8 +52,8 @@ describe('Breakpoint discovery', function () {
                 }),
                 quux: () => true,
             })
-        }));
-        expect(getBreakpoints(store)).toBe(defaultBreakpoints);
+        }))
+        expect(getBreakpoints(store)).toBe(defaultBreakpoints)
     })
 
     it('Can find responsive state anywhere in the ImmutableJS Map', function() {
@@ -64,8 +64,8 @@ describe('Breakpoint discovery', function () {
                 }),
                 quux: () => true,
             })
-        }));
-        expect(getBreakpoints(store)).toBe(defaultBreakpoints);
+        }))
+        expect(getBreakpoints(store)).toBe(defaultBreakpoints)
     })
 
 
@@ -77,7 +77,7 @@ describe('Breakpoint discovery', function () {
                 })(),
                 quux: true,
             })()
-        });
+        })
         const store = createStore(immutableCombine({
             foo: immutableCombine({
                 bar: immutableCombine({
@@ -85,8 +85,8 @@ describe('Breakpoint discovery', function () {
                 }),
                 quux: () => true,
             })
-        }, StateRecord));
-        expect(getBreakpoints(store)).toBe(defaultBreakpoints);
+        }, StateRecord))
+        expect(getBreakpoints(store)).toBe(defaultBreakpoints)
     })
 
     it('Complains if it cannot find a reducer at root', function() {


### PR DESCRIPTION
This lifts the restriction of having to have the reducer at the top of the state tree. Now it can be embedded at any depth and we find it with the breadth-first search algorithm. 