### PR TITLE
Redux 3 compatibility of types

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "test:coverage": "npm run test -- --coverage",
         "test:coverage:report": "npm run test:coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
         "test:coverage:report:types": "npm run test:coverage:report && npm run test:types",
-        "__internal__prettier": "prettier 'src/**/*.js'",
+        "__internal__prettier": "prettier 'src/**/*.js' 'types/**/*'",
         "format": "npm run __internal__prettier -- --write"
     },
     "license": "MIT",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,13 @@
-// TypeScript Version: 2.3
+// TypeScript Version: 2.4
 
-import { Reducer, StoreEnhancer } from 'redux';
+import { Reducer, StoreEnhancerStoreCreator } from 'redux';
+
+export interface IResponsiveEnhancer {
+    <S>(next: StoreEnhancerStoreCreator<S>): StoreEnhancerStoreCreator<S>;
+}
+
+// export type GenericStoreEnhancer = <S>(next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
+// export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, preloadedState?: S) => Store<S>;
 
 export type BreakPointsDefaultNames = "extraSmall" | "small" | "medium" | "large" | "extraLarge" | "infinity";
 
@@ -48,11 +55,11 @@ export function createResponsiveStateReducer<
     EF = {}
 >(breakpoints: undefined | null, options?: IResponsiveReducerOptions<IBreakPoints, EF>): Reducer<IBrowser & EF>;
 
-export function createResponsiveStoreEnhancer(options?: IResponsiveEnhancerOptions): StoreEnhancer;
+export function createResponsiveStoreEnhancer(options?: IResponsiveEnhancerOptions): IResponsiveEnhancer;
 
 export const responsiveStateReducer: Reducer<IBrowser>;
 
-export const responsiveStoreEnhancer: StoreEnhancer;
+export const responsiveStoreEnhancer: IResponsiveEnhancer;
 
 export interface ICalculateResponsiveStateAction {
     type: "redux-responsive/CALCULATE_RESPONSIVE_STATE";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,9 +6,6 @@ export interface IResponsiveEnhancer {
     <S>(next: StoreEnhancerStoreCreator<S>): StoreEnhancerStoreCreator<S>
 }
 
-// export type GenericStoreEnhancer = <S>(next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
-// export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, preloadedState?: S) => Store<S>;
-
 export type BreakPointsDefaultNames =
     | 'extraSmall'
     | 'small'

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,42 +1,46 @@
 // TypeScript Version: 2.4
 
-import { Reducer, StoreEnhancerStoreCreator } from 'redux';
+import { Reducer, StoreEnhancerStoreCreator } from 'redux'
 
 export interface IResponsiveEnhancer {
-    <S>(next: StoreEnhancerStoreCreator<S>): StoreEnhancerStoreCreator<S>;
+    <S>(next: StoreEnhancerStoreCreator<S>): StoreEnhancerStoreCreator<S>
 }
 
 // export type GenericStoreEnhancer = <S>(next: StoreEnhancerStoreCreator<S>) => StoreEnhancerStoreCreator<S>;
 // export type StoreEnhancerStoreCreator<S> = (reducer: Reducer<S>, preloadedState?: S) => Store<S>;
 
-export type BreakPointsDefaultNames = "extraSmall" | "small" | "medium" | "large" | "extraLarge" | "infinity";
+export type BreakPointsDefaultNames =
+    | 'extraSmall'
+    | 'small'
+    | 'medium'
+    | 'large'
+    | 'extraLarge'
+    | 'infinity'
 
 export type IBreakPoints<BPNames extends string = BreakPointsDefaultNames> = {
-    [k in BPNames]: number | string;
-};
+    [k in BPNames]: number | string
+}
 
-export type IBreakPointResults<BP = IBreakPoints> = {
-    [k in keyof BP]: boolean;
-};
+export type IBreakPointResults<BP = IBreakPoints> = { [k in keyof BP]: boolean }
 
 export interface IBrowser<BP = IBreakPoints> {
-    _responsiveState: boolean;
-    mediaType: string;
-    orientation: string;
-    lessThan: IBreakPointResults<BP>;
-    greaterThan: IBreakPointResults<BP>;
-    is: IBreakPointResults<BP>;
-    breakpoints: BP;
+    _responsiveState: boolean
+    mediaType: string
+    orientation: string
+    lessThan: IBreakPointResults<BP>
+    greaterThan: IBreakPointResults<BP>
+    is: IBreakPointResults<BP>
+    breakpoints: BP
 }
 
 export interface IResponsiveReducerOptions<BP = IBreakPoints, EF = {}> {
-    initialMediaType?: string;
-    infinity?: string;
-    extraFields?(breakPoints: IBrowser<BP>): EF;
+    initialMediaType?: string
+    infinity?: string
+    extraFields?(breakPoints: IBrowser<BP>): EF
 }
 
 export interface IResponsiveEnhancerOptions {
-    calculateInitialState?: boolean;
+    calculateInitialState?: boolean
 }
 
 /*
@@ -46,24 +50,27 @@ export interface IResponsiveEnhancerOptions {
 
 so instead we use overloads
 */
-export function createResponsiveStateReducer(): Reducer<IBrowser>;
-export function createResponsiveStateReducer<
-    BP extends IBreakPoints<string>,
-    EF = {}
->(breakpoints: BP, options?: IResponsiveReducerOptions<BP, EF>): Reducer<IBrowser<BP> & EF>;
-export function createResponsiveStateReducer<
-    EF = {}
->(breakpoints: undefined | null, options?: IResponsiveReducerOptions<IBreakPoints, EF>): Reducer<IBrowser & EF>;
+export function createResponsiveStateReducer(): Reducer<IBrowser>
+export function createResponsiveStateReducer<BP extends IBreakPoints<string>, EF = {}>(
+    breakpoints: BP,
+    options?: IResponsiveReducerOptions<BP, EF>
+): Reducer<IBrowser<BP> & EF>
+export function createResponsiveStateReducer<EF = {}>(
+    breakpoints: undefined | null,
+    options?: IResponsiveReducerOptions<IBreakPoints, EF>
+): Reducer<IBrowser & EF>
 
-export function createResponsiveStoreEnhancer(options?: IResponsiveEnhancerOptions): IResponsiveEnhancer;
+export function createResponsiveStoreEnhancer(
+    options?: IResponsiveEnhancerOptions
+): IResponsiveEnhancer
 
-export const responsiveStateReducer: Reducer<IBrowser>;
+export const responsiveStateReducer: Reducer<IBrowser>
 
-export const responsiveStoreEnhancer: IResponsiveEnhancer;
+export const responsiveStoreEnhancer: IResponsiveEnhancer
 
 export interface ICalculateResponsiveStateAction {
-    type: "redux-responsive/CALCULATE_RESPONSIVE_STATE";
+    type: 'redux-responsive/CALCULATE_RESPONSIVE_STATE'
 }
 
-export type IWindowLike = Pick<Window, "innerWidth" | "innerHeight" | "matchMedia">;
-export function calculateResponsiveState(window: IWindowLike): ICalculateResponsiveStateAction;
+export type IWindowLike = Pick<Window, 'innerWidth' | 'innerHeight' | 'matchMedia'>
+export function calculateResponsiveState(window: IWindowLike): ICalculateResponsiveStateAction

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -7,17 +7,14 @@ import {
 } from "redux-responsive";
 import { Action, createStore } from "redux";
 
-// $ExpectType StoreEnhancer<{}, {}>
+// $ExpectType IResponsiveEnhancer
 createResponsiveStoreEnhancer();
 
-// $ExpectType StoreEnhancer<{}, {}>
+// $ExpectType IResponsiveEnhancer
 createResponsiveStoreEnhancer({});
 
-// $ExpectType Reducer<IBrowser<IBreakPoints<BreakPointsDefaultNames>>, AnyAction>
-createResponsiveStateReducer();
-
-// $ExpectType Reducer<IBrowser<IBreakPoints<BreakPointsDefaultNames>>, AnyAction>
-createResponsiveStateReducer(void 0, {});
+// $ExpectType string
+createStore(responsiveStateReducer, responsiveStoreEnhancer).getState().orientation;
 
 // $ExpectType boolean
 createStore(responsiveStateReducer).getState().greaterThan.small;

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -3,64 +3,66 @@ import {
     createResponsiveStoreEnhancer,
     responsiveStateReducer,
     responsiveStoreEnhancer,
-    IBrowser, calculateResponsiveState, IBreakPoints,
-} from "redux-responsive";
-import { Action, createStore } from "redux";
+    IBrowser,
+    calculateResponsiveState,
+    IBreakPoints,
+} from 'redux-responsive'
+import { Action, createStore } from 'redux'
 
 // $ExpectType IResponsiveEnhancer
-createResponsiveStoreEnhancer();
+createResponsiveStoreEnhancer()
 
 // $ExpectType IResponsiveEnhancer
-createResponsiveStoreEnhancer({});
+createResponsiveStoreEnhancer({})
 
 // $ExpectType string
-createStore(responsiveStateReducer, responsiveStoreEnhancer).getState().orientation;
+createStore(responsiveStateReducer, responsiveStoreEnhancer).getState().orientation
 
 // $ExpectType boolean
-createStore(responsiveStateReducer).getState().greaterThan.small;
+createStore(responsiveStateReducer).getState().greaterThan.small
 
 // $ExpectType "redux-responsive/CALCULATE_RESPONSIVE_STATE"
-calculateResponsiveState(window).type;
+calculateResponsiveState(window).type
 
-const customBreaks: IBreakPoints<"big" | "veryBig" | "superBig" | "print"> = {
+const customBreaks: IBreakPoints<'big' | 'veryBig' | 'superBig' | 'print'> = {
     big: 500,
     veryBig: 5000,
     superBig: 50000,
-    print: "print",
-};
-const reducer = createResponsiveStateReducer(customBreaks);
-const store = createStore(reducer);
+    print: 'print',
+}
+const reducer = createResponsiveStateReducer(customBreaks)
+const store = createStore(reducer)
 // $ExpectType boolean
-store.getState().greaterThan.superBig;
+store.getState().greaterThan.superBig
 // $ExpectType boolean
-store.getState().greaterThan.print;
+store.getState().greaterThan.print
 // $ExpectError
-store.getState().greaterThan.small;
+store.getState().greaterThan.small
 
 const reducer2 = createResponsiveStateReducer(void 0, {
     extraFields(s) {
         // $ExpectType IBrowser<IBreakPoints<BreakPointsDefaultNames>>
-        s;
-        return { foo: 1 };
-    }
-});
-const store2 = createStore(reducer2);
+        s
+        return { foo: 1 }
+    },
+})
+const store2 = createStore(reducer2)
 // $ExpectType number
-store2.getState().foo;
+store2.getState().foo
 // $ExpectError
-store2.getState().bar;
+store2.getState().bar
 
 const reducer3 = createResponsiveStateReducer(customBreaks, {
     extraFields(s) {
         // $ExpectType IBrowser<IBreakPoints<"big" | "veryBig" | "superBig" | "print">>
-        s;
-        return { foo: 1 };
-    }
-});
-const store3 = createStore(reducer3);
+        s
+        return { foo: 1 }
+    },
+})
+const store3 = createStore(reducer3)
 // $ExpectType number
-store3.getState().foo;
+store3.getState().foo
 // $ExpectError
-store3.getState().bar;
+store3.getState().bar
 // $ExpectType boolean
-store3.getState().greaterThan.print;
+store3.getState().greaterThan.print

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,14 +1,14 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "lib": ["es5", "dom"],
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "baseUrl": ".",
-    "paths": {
-      "redux-responsive": ["."]
+    "compilerOptions": {
+        "module": "commonjs",
+        "lib": ["es5", "dom"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "baseUrl": ".",
+        "paths": {
+            "redux-responsive": ["."]
+        }
     }
-  }
 }

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,7 +1,8 @@
 {
-  "extends": "dtslint/dtslint.json",
-  "rules": {
-    "callable-types": false,
-    "interface-name": [true, "always-prefix"]
-  }
+    "extends": "dtslint/dtslint.json",
+    "rules": {
+        "callable-types": false,
+        "interface-name": [true, "always-prefix"],
+        "semicolon": false
+    }
 }


### PR DESCRIPTION
Since `StoreEnhancer` types have different generic arguments in Redux 3 and 4, I had to make my own `IResponsiveEnhancer` type. Note: minimal version of typescript is changed to 2.4 (there was a bug where `createStore(responsiveStateReducer, responsiveStoreEnhancer).getState()` was typed as `any` instead of proper `IBrowser`). This only affects running tests, though. Users of TS 2.3 had to work around this with casts anyway, and users of TS 2.4+ did not have the bug.